### PR TITLE
Repair illegal substitutions to an inversion

### DIFF
--- a/src/clj_hgvs/mutation.cljc
+++ b/src/clj_hgvs/mutation.cljc
@@ -338,7 +338,7 @@
    (DNADeletion. coord-start coord-end ref)))
 
 (def ^:private dna-deletion-re
-  #"([\(\)\*\-\+\d\?_]+)del([A-Z]+)?")
+  #"([\(\)\*\-\+\d\?_]+)del([A-Z0-9]+)?")
 
 (defn parse-dna-deletion
   [s kind]

--- a/src/clj_hgvs/mutation.cljc
+++ b/src/clj_hgvs/mutation.cljc
@@ -338,7 +338,7 @@
    (DNADeletion. coord-start coord-end ref)))
 
 (def ^:private dna-deletion-re
-  #"([\(\)\*\-\+\d\?_]+)del([A-Z0-9]+)?")
+  #"([\(\)\*\-\+\d\?_]+)del([A-Z]+)?")
 
 (defn parse-dna-deletion
   [s kind]

--- a/src/clj_hgvs/repairer.cljc
+++ b/src/clj_hgvs/repairer.cljc
@@ -118,7 +118,6 @@
                           (str coords "inv")
                           s))))))
 
-
 ;; c.123_123delAinsTAC -> c.123delAinsTAC
 ;; g.123_123[14] -> g.123[14]
 (defn ^:no-doc remove-same-end

--- a/src/clj_hgvs/repairer.cljc
+++ b/src/clj_hgvs/repairer.cljc
@@ -112,13 +112,13 @@
 (defn ^:no-doc basis->inv
   [s kind]
   (let [base-pairs {\A \T \T \A \C \G \G \C}
-        [_ region b a] (re-find #"c\.(\d+_\d+)([A-Z]+)>([A-Z]+)" s)]
+        [_ region b a] (re-find #"(\d+_\d+)([A-Z]+)>([A-Z]+)" s)]
     (if (= a
            (->> b
                 (map base-pairs)
                 reverse
                 (apply str)))
-      (str region "inv")
+      (str "c." region "inv")
       s)))
 
 ;; c.123_123delAinsTAC -> c.123delAinsTAC

--- a/src/clj_hgvs/repairer.cljc
+++ b/src/clj_hgvs/repairer.cljc
@@ -87,6 +87,12 @@
     (string/replace s #"([-\d+*]+_[-\d+*]+)([A-Z]+)?>([A-Z]+)" "$1del$2ins$3")
     s))
 
+;; c.233_234TC>CT	-> c.233_234delinsCT
+(defn ^:no-doc substitutions->delins*
+  [s kind]
+  (if (= :coding-dna kind)
+    (string/replace s #"([A-Z]?[-\d+*]+_[A-Z]?[-\d+*]+)([A-Z]+)?>([A-Z]+)" "$1delins$3")))
+
 ;; c.123_124delCT[hg19] -> c.123_124delCT
 (defn ^:no-doc remove-assembly
   [s _]
@@ -101,6 +107,19 @@
        kind)
     (string/replace s #"(del|dup|inv)\d+$" "$1")
     s))
+
+;; c.2210_2211CA>TG	-> c.2210_2211inv
+(defn ^:no-doc basis->inv
+  [s kind]
+  (let [base-pairs {\A \T \T \A \C \G \G \C}
+        [_ region b a] (re-find #"c\.(\d+_\d+)([A-Z]+)>([A-Z]+)" s)]
+    (if (= a
+           (->> b
+                (map base-pairs)
+                reverse
+                (apply str)))
+      (str region "inv")
+      s)))
 
 ;; c.123_123delAinsTAC -> c.123delAinsTAC
 ;; g.123_123[14] -> g.123[14]

--- a/src/clj_hgvs/repairer.cljc
+++ b/src/clj_hgvs/repairer.cljc
@@ -113,10 +113,11 @@
                    (apply str)))]
       (string/replace s
                       #"([-\d+*]+_[-\d+*]+)([A-Z]{2,})>([A-Z]{2,})"
-                      (fn [[s coords del ins]]
+                      (fn [[s* coords del ins]]
                         (if (= del (revcomp ins))
                           (str coords "inv")
-                          s))))))
+                          s*))))
+    s))
 
 ;; c.123_123delAinsTAC -> c.123delAinsTAC
 ;; g.123_123[14] -> g.123[14]

--- a/test/clj_hgvs/core_test.cljc
+++ b/test/clj_hgvs/core_test.cljc
@@ -283,6 +283,9 @@
     "p.Gln13Stop" "p.Gln13Ter"
     "p.Tyr9stop"  "p.Tyr9Ter"
 
+    ;; substitutions->inv
+    "c.1234_1235CA>TG"	"c.1234_1235inv"
+
     ;; substitution->delins
     "c.123G>CCACGTG" "c.123delGinsCCACGTG"
 


### PR DESCRIPTION
I added two repairer functions to correct illegal hgvs strings.
Could you review this?