### PR TITLE
feat: parse HGVS with Ensembl stable ID

### DIFF
--- a/src/clj_hgvs/core.cljc
+++ b/src/clj_hgvs/core.cljc
@@ -25,7 +25,7 @@
   (s/and string? (s/or :N*_  #(re-matches #"N(C|G|M|R|P)_\d+(\.\d+)?" %)
                        :LRG_ #(re-matches #"LRG_\d+((t|p)\d+)?" %)
                        :J*   #(re-matches #"J\d+(\.\d+)?" %)
-                       :MGP_* #(re-matches #"MGP_[a-zA-Z0-9]+_(G|T|P)\d{11}(\.\d+)?" %)
+                       :MGP_* #(re-matches #"MGP_[a-zA-Z0-9]+_(G|T|P)\d{7}(\.\d+)?" %)
                        :ENS* #(re-matches #"ENS([A-Z]{3})?(G|T|P)\d{11}(\.\d+)?" %))))
 
 (s/def ::kind #{:genome

--- a/test/clj_hgvs/core_test.cljc
+++ b/test/clj_hgvs/core_test.cljc
@@ -23,13 +23,13 @@
     "J01749.1"
     "ENST00000000001.1"
     "ENSP00000000001.11"
-    "MGP_CBAJ_G00000000002.1")
+    "MGP_CBAJ_G0000002.1")
   (are [s] (not (s/valid? ::hgvs/transcript s))
     "LRG_199.1"
     "NT_000023.10"
     "ENST0001"
     "ENSF00000000001.1"
-    "MGP_CBAJ_P0000000002.1"))
+    "MGP_CBAJ_P000002.1"))
 
 (def hgvs1s "NM_005228.3:c.2361G>A")
 (def hgvs1m (hgvs/map->HGVS


### PR DESCRIPTION
- according to HGVS, only ["ENST" and "ENSP" are recommended](https://varnomen.hgvs.org/bg-material/refseq/)
- definition of stable Ensembl IDs are [here](https://asia.ensembl.org/info/genome/stable_ids/prefixes.html)