### PR TITLE
Explicitly install leiningen on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Install dependencies
       run: lein deps
     - name: Run tests
@@ -46,6 +50,10 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '17'
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Install dependencies
       run: lein deps
     - name: Generate code coverage
@@ -79,6 +87,10 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '17'
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Deploy
       env:
         CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}


### PR DESCRIPTION
related: https://github.com/chrovis/cljam/pull/331

The OS version of the runner instances provided by `ubuntu-latest` in GitHub Actions [will be upgraded from 22.04 to 24.04 between 2024/12/05 and 2025/01/17](https://github.com/actions/runner-images/issues/10636).
Unlike 22.04, Leiningen is not pre-installed on 24.04. Therefore, I have modified the workflow to explicitly install it using [DeLaGuardo/setup-clojure](https://github.com/DeLaGuardo/setup-clojure).
